### PR TITLE
Fixed autocommit calls for mysql-connector-python

### DIFF
--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -52,7 +52,10 @@ class MySqlHook(DbApiHook):
 
     def set_autocommit(self, conn: Connection, autocommit: bool) -> None:  # noqa: D403
         """MySql connection sets autocommit in a different way."""
-        conn.autocommit(autocommit)
+        if hasattr(conn, 'get_autocommit'): # mysqlclient
+            conn.autocommit(autocommit)
+        else: # mysql-connector-python
+            conn.autocommit = autocommit
 
     def get_autocommit(self, conn: Connection) -> bool:  # noqa: D403
         """
@@ -63,7 +66,10 @@ class MySqlHook(DbApiHook):
         :return: connection autocommit setting
         :rtype: bool
         """
-        return conn.get_autocommit()
+        if hasattr(conn, 'get_autocommit'): # mysqlclient
+            return conn.get_autocommit()
+        else: # mysql-connector-python
+            return conn.autocommit
 
     def _get_conn_config_mysql_client(self, conn: Connection) -> Dict:
         conn_config = {


### PR DESCRIPTION
The MySQLdb and mysql-connector-python clients use different methods for getting and setting the autocommit mode. This code checks the `conn` param passed into get/set_autocommit() to see if it's a MySQLdb instance (containing the get_autocommit method) or a mysql-connector-python instance (missing get_autocommit) and makes the appropriate autocommit calls for the client.

Fixes #14857

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
